### PR TITLE
Some small refinements and debugging of the visualizations.

### DIFF
--- a/fedmoe/datasets/time_series_data.py
+++ b/fedmoe/datasets/time_series_data.py
@@ -460,6 +460,7 @@ class TimeSeriesData:
             f"Error:server output matrix has a shape {server_matrix.shape},\
                 but it should be{(self.total_time_steps, self.target_matrix.shape[1])}"
         }
+
         squared_error = (server_matrix - self.target_matrix) ** 2
         squared_error = squared_error.flatten()
         plt.hist(squared_error, bins=10)
@@ -472,16 +473,189 @@ class TimeSeriesData:
                 num_items += 1
                 if num_items % 6 == 0:
                     text_content += "\n"
-            plt.text(0.5, -0.2, text_content, ha="center", va="top", transform=plt.gca().transAxes)
+            plt.text(0.5, -0.2, text_content.rstrip(",\n"), ha="center", va="top", transform=plt.gca().transAxes)
             plt.subplots_adjust(bottom=0.2)
 
-        game_status = "with" if game_played else "without"
+        game_status = "" if game_played else "No "
 
-        plt.xlabel("Squared Error values")
-        plt.ylabel("Count of Squared Error values")
-        plt.title(f"Histogram of Squared Error {game_status} the game ")
+        title_font = {"family": "helvetica", "weight": "bold", "size": 20}
+        axis_font = {"family": "helvetica", "weight": "bold", "size": 18}
+        plt.xticks(fontname="helvetica", fontsize=14, fontweight="bold")
+        plt.yticks(fontname="helvetica", fontsize=14, fontweight="bold")
+        plt.xlabel("Squared Error Bins", fontdict=axis_font)
+        plt.ylabel("Squared Error Counts", fontdict=axis_font)
+        plt.title(f"Histogram of Squared Errors ({game_status}Nash Game)", fontdict=title_font)
 
-        plt.legend()
+        plt.tight_layout(pad=0.5)
+
+        plt.savefig(plot_path)
+
+        plt.close()
+
+    def visualize_server_squared_errors(
+        self,
+        server_prediction: List[torch.Tensor],
+        plot_path: str,
+        game_played: bool = False,
+        T: int = 0,
+        show_points: Optional[bool] = False,
+        plot_info: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        Saves a time series plot showing the server prediction squared errors
+        """
+
+        if game_played:
+            assert T > 0, "Error: if the game is played, T should be greater than zero."
+
+        server_matrix = torch.stack(server_prediction, dim=0).squeeze(-1)
+        assert server_matrix.shape == (self.total_time_steps, self.target_matrix.shape[1]), {
+            f"Error:server output matrix has a shape {server_matrix.shape},\
+                but it should be{(self.total_time_steps, self.target_matrix.shape[1])}"
+        }
+
+        squared_error = (server_matrix - self.target_matrix) ** 2
+
+        # Plot server's prediction squared errors
+        for i in range(server_matrix.shape[1]):
+            plt.plot(
+                self.time_axis,
+                squared_error[:, i].detach().numpy(),
+                label=f"$(\\hat{{Y}}_{i+1} - y_{i+1})^2$",
+                linestyle="-",
+                linewidth=2.5,
+            )
+
+        if game_played:
+            if show_points:
+                # Display synchronization steps as points
+                for i in range(server_matrix.shape[1]):
+                    T_indices = [i * T for i in range(1, int(self.total_time_steps / T))]
+                    T_values = [squared_error[j, i].detach().numpy().item() for j in T_indices]
+                    plt.scatter(
+                        T_indices,
+                        T_values,
+                        s=75,
+                        marker="o",
+                        facecolors="r",
+                        edgecolors="r",
+                        zorder=3,
+                    )
+            else:
+                # Display synchronization steps as vertical lines instead
+                for j in range(1, int(self.total_time_steps / T)):
+                    label = "Nash Game Played" if j == 1 else None
+                    plt.axvline(x=j * T, color="red", linestyle="--", linewidth=1.5, label=label)
+
+        if plot_info is not None:
+            text_content = ""
+            num_items = 0
+            for key, value in plot_info.items():
+                text_content += f"{key}: {value},"
+                num_items += 1
+                if num_items % 6 == 0:
+                    text_content += "\n"
+            plt.text(0.5, -0.2, text_content.rstrip(",\n"), ha="center", va="top", transform=plt.gca().transAxes)
+            plt.subplots_adjust(bottom=0.2)
+
+        game_status = "" if game_played else "No "
+
+        title_font = {"family": "helvetica", "weight": "bold", "size": 20}
+        axis_font = {"family": "helvetica", "weight": "bold", "size": 18}
+        plt.xticks(ticks=self.time_axis.flatten(), fontname="helvetica", fontsize=14, fontweight="bold")
+        plt.yticks(fontname="helvetica", fontsize=14, fontweight="bold")
+        plt.xlabel("Time Step", fontdict=axis_font)
+        plt.ylabel("Squared Error Values", fontdict=axis_font)
+        plt.title(f"Server Squared Errors ({game_status}Nash Game)", fontdict=title_font)
+
+        plt.legend(prop={"family": "helvetica", "weight": "bold", "size": 12}, labelspacing=0)
+        plt.tight_layout(pad=0.5)
+
+        plt.savefig(plot_path)
+
+        plt.close()
+
+    def visualize_client_squared_errors(
+        self,
+        client_predictions: List[torch.Tensor],
+        plot_path: str,
+        plot_info: Dict[str, Any],
+        game_played: bool = False,
+        T: int = 0,
+        show_points: Optional[bool] = False,
+    ) -> None:
+        """
+        Saves a time series plot showing the client prediction squared errors
+        """
+
+        if game_played:
+            assert T > 0, "Error: if the game is played, T should be greater than zero."
+
+        clients_pred_matrix = torch.stack(client_predictions, dim=0)
+        assert clients_pred_matrix.shape == (
+            self.total_time_steps,
+            plot_info["num_clients"],
+            self.target_matrix.shape[1],
+        ), {
+            f"Error: client prediction matrix shape is {clients_pred_matrix.shape},\
+            but it should be {(self.total_time_steps, plot_info['num_clients'], self.target_matrix.shape[1])}"
+        }
+
+        for client in range(int(plot_info["num_clients"])):
+            for dim in range(clients_pred_matrix.shape[2]):
+                squared_error = (clients_pred_matrix[:, client, dim] - self.target_matrix[:, dim]) ** 2
+                plt.plot(
+                    self.time_axis,
+                    squared_error,
+                    label=f"$\\mathregular{{Client}}_{client}$: $(\\hat{{Y}}_{dim+1} - y_{dim+1})^2$",
+                    linestyle="-",
+                    linewidth=2.5,
+                )
+
+                if game_played and show_points:
+                    # Display synchronization steps as points
+                    T_indices = [i * T for i in range(1, int(self.total_time_steps / T))]
+                    T_values = [squared_error[j].detach().numpy().item() for j in T_indices]
+                    plt.scatter(
+                        T_indices,
+                        T_values,
+                        s=75,
+                        marker="o",
+                        facecolors="r",
+                        edgecolors="r",
+                        zorder=3,
+                    )
+
+        if game_played and not show_points:
+            # Display synchronization steps as vertical lines instead
+            for j in range(1, int(self.total_time_steps / T)):
+                label = "Nash Game Played" if j == 1 else None
+                plt.axvline(x=j * T, color="red", linestyle="--", linewidth=1.5, label=label)
+
+        if plot_info is not None:
+            text_content = ""
+            num_items = 0
+            for key, value in plot_info.items():
+                text_content += f"{key}: {value},"
+                num_items += 1
+                if num_items % 6 == 0:
+                    text_content += "\n"
+            plt.text(0.5, -0.2, text_content.rstrip(",\n"), ha="center", va="top", transform=plt.gca().transAxes)
+            plt.subplots_adjust(bottom=0.2)
+
+        game_status = "" if game_played else "No "
+
+        title_font = {"family": "helvetica", "weight": "bold", "size": 20}
+        axis_font = {"family": "helvetica", "weight": "bold", "size": 18}
+        plt.xticks(ticks=self.time_axis.flatten(), fontname="helvetica", fontsize=14, fontweight="bold")
+        plt.yticks(fontname="helvetica", fontsize=14, fontweight="bold")
+        plt.xlabel("Time Step", fontdict=axis_font)
+        plt.ylabel("Squared Error Values", fontdict=axis_font)
+        plt.title(f"Client Squared Errors ({game_status}Nash Game)", fontdict=title_font)
+
+        plt.legend(prop={"family": "helvetica", "weight": "bold", "size": 12}, labelspacing=0)
+        plt.tight_layout(pad=0.5)
+
         plt.savefig(plot_path)
 
         plt.close()

--- a/fedmoe/tests/datasets/test_time_series_visualization.py
+++ b/fedmoe/tests/datasets/test_time_series_visualization.py
@@ -110,3 +110,102 @@ def test_visualize_mixture_weights(tmp_path: Path) -> None:
         show_lines=True,
         T=2,
     )
+
+
+def test_visualize_errors_histogram(tmp_path: Path) -> None:
+    save_dir = tmp_path.joinpath("artifacts")
+    save_dir.mkdir()
+    # Set this value to true if you want to see the generated plots
+    save_plots = False
+    if save_plots:
+        save_dir = Path("fedmoe/tests/datasets/artifacts")
+    # variables
+    time_steps = 15
+    num_clients = 2
+    two_d_data_obj = TimeSeries2DXY(total_time_steps=time_steps)
+    manual_server_prediction = []
+    for t in range(time_steps):
+        manual_server_prediction.append(torch.Tensor([10 * t, 100 * t]))
+
+    plot_info = {
+        "num_clients": num_clients,
+    }
+    two_d_data_obj.visualize_squared_error_histogram(
+        manual_server_prediction, f"{save_dir}/errors_histogram.png", plot_info=plot_info
+    )
+
+
+def test_visualize_server_prediction_errors(tmp_path: Path) -> None:
+    save_dir = tmp_path.joinpath("artifacts")
+    save_dir.mkdir()
+    # Set this value to true if you want to see the generated plots
+    save_plots = False
+    if save_plots:
+        save_dir = Path("fedmoe/tests/datasets/artifacts")
+    # variables
+    time_steps = 10
+    two_d_data_obj = TimeSeries2DXY(total_time_steps=time_steps)
+    assert two_d_data_obj.input_matrix.shape == (time_steps, 2)
+    assert two_d_data_obj.target_matrix.shape == (time_steps, 2)
+    manual_server_prediction = []
+    for t in range(time_steps):
+        manual_server_prediction.append(torch.Tensor([10 * t, 30 * t]))
+    plot_info = {
+        "num_clients": 2,
+        "T": 1,
+        "d_z": 2,
+        "alpha": 1,
+        "gamma": 1,
+        "sigma": 1,
+    }
+    two_d_data_obj.visualize_server_squared_errors(
+        manual_server_prediction, f"{save_dir}/test_plot_server_errors.png", game_played=True, T=2, plot_info=plot_info
+    )
+    two_d_data_obj.visualize_server_squared_errors(
+        manual_server_prediction,
+        f"{save_dir}/test_plot_server_errors_2.png",
+        game_played=True,
+        T=2,
+        show_points=True,
+        plot_info=plot_info,
+    )
+
+
+def test_visualize_clients_errors(tmp_path: Path) -> None:
+    save_dir = tmp_path.joinpath("artifacts")
+    save_dir.mkdir()
+    # Set this value to true if you want to see the generated plots
+    save_plots = False
+    if save_plots:
+        save_dir = Path("fedmoe/tests/datasets/artifacts")
+    # variables
+    time_steps = 10
+    num_clients = 2
+    two_d_data_obj = TimeSeries2DXY(total_time_steps=time_steps)
+
+    manual_clients_predictions = []
+    for t in range(time_steps):
+        client_predictions = []
+        for client in range(num_clients):
+            client_predictions.append(torch.Tensor([[50 * t], [100 * t * (client + 1)]]))
+        manual_clients_predictions.append(torch.cat(client_predictions, dim=1))
+    plot_info = {
+        "num_clients": num_clients,
+    }
+    two_d_data_obj.visualize_client_squared_errors(
+        manual_clients_predictions,
+        f"{save_dir}/client_error_plot.png",
+        plot_info=plot_info,
+        game_played=True,
+        T=2,
+        show_points=True,
+    )
+
+    two_d_data_obj.visualize_client_squared_errors(
+        manual_clients_predictions,
+        f"{save_dir}/client_error_plot_2.png",
+        plot_info=plot_info,
+        game_played=True,
+        T=2,
+        show_points=False,
+    )


### PR DESCRIPTION
This PR applies a few small tweaks to the way that we visualize the time-series targets, predictions, etc. Mostly, it applies a few more controls to make the plots slightly better when rendered as part of a latex PDF. I imagine there will be a few additional tweaks necessary to make them fully ready for a manuscript, but this is hopefully a good start. 

A few examples generated by our tests appear below. You'll notice that the fonts, line thicknesses, etc. are a bit exaggerated. This is because when latex rendered and made smaller, these exaggerations are less pronounced but make the plots easier to read. Again, there will likely need to be tweaks for real experiment data, but hopefully these are reasonable baselines.
![client_pred_plot](https://github.com/user-attachments/assets/4bad9dd5-e38f-4812-bdd7-559fa75cc24e)
![mixture_weights_plot_2](https://github.com/user-attachments/assets/70aaff53-1817-43a5-8598-0c29c17527b9)
![mixture_weights_plot](https://github.com/user-attachments/assets/a7a901a7-9413-4ba6-b2b5-a9279dfb3e3a)
![test_plot_input](https://github.com/user-attachments/assets/3b7d8f88-4c75-4259-a3fa-f51f5e00b64f)
![test_plot_server_2](https://github.com/user-attachments/assets/daa0e1eb-5e30-43a8-aa61-d3e59dd6a215)
![test_plot_server_3](https://github.com/user-attachments/assets/e25d6c07-d1fb-41cf-a3e8-d4d81175e801)
![test_plot_server](https://github.com/user-attachments/assets/645afe19-1333-4a78-a145-7746f6ad6053)
![client_error_plot_2](https://github.com/user-attachments/assets/7725ebcf-3398-46ef-bc91-bdba8a325cac)
![client_error_plot](https://github.com/user-attachments/assets/84180f29-0bdb-4a11-9b1f-be0339b5b844)
![errors_histogram](https://github.com/user-attachments/assets/b4268e7b-7bbb-4beb-b550-525ea5f3725c)
![test_plot_server_errors_2](https://github.com/user-attachments/assets/0b8335e2-7550-492e-b1cd-0f779b702f12)
![test_plot_server_errors](https://github.com/user-attachments/assets/90ba2a49-c84a-46f5-b5c9-8f94e115a789)